### PR TITLE
docs: add Javadoc to /services functions and classes

### DIFF
--- a/src/main/java/dd2480/group17/ciserver/service/CompileService.java
+++ b/src/main/java/dd2480/group17/ciserver/service/CompileService.java
@@ -4,6 +4,18 @@ import dd2480.group17.ciserver.infrastructure.MavenExecutor;
 import dd2480.group17.ciserver.infrastructure.dto.CompileDTO;
 import dd2480.group17.ciserver.utils.Logger;
 
+/**
+ * The {@code CompileService} class is responsible for compiling the code in a
+ * specified repository path
+ * using Maven and logging the compilation results.
+ * <p>
+ * This class represents the compilation process to {@link MavenExecutor} and
+ * logs the output and errors using
+ * {@link Logger}. It plays a critical role in the Continuous Integration (CI)
+ * pipeline by determining whether
+ * a build is successful or not.
+ * </p>
+ */
 public class CompileService {
 
     private static final MavenExecutor mavenExecutor = new MavenExecutor();

--- a/src/main/java/dd2480/group17/ciserver/service/CompileService.java
+++ b/src/main/java/dd2480/group17/ciserver/service/CompileService.java
@@ -9,6 +9,14 @@ public class CompileService {
     private static final MavenExecutor mavenExecutor = new MavenExecutor();
     private static final Logger logger = new Logger();
 
+    /**
+     * Compiles the code in the specified repository path and logs the result
+     * 
+     * @param repoPath the file system path to the repository that needs to be
+     *                 compiled
+     * @param commitId the commit hash used for identifying the build in the logs
+     * @return true if the compilation is successful, false otherwise
+     */
     public boolean compileCode(String repoPath, String commitId) {
         CompileDTO result = mavenExecutor.runCompile(repoPath);
         logger.logCompileEvent(commitId, result.getOutput(), result.getError());

--- a/src/main/java/dd2480/group17/ciserver/service/GitService.java
+++ b/src/main/java/dd2480/group17/ciserver/service/GitService.java
@@ -2,6 +2,14 @@ package dd2480.group17.ciserver.service;
 
 import dd2480.group17.ciserver.infrastructure.GitHandler;
 
+/**
+ * The {@code GitService} class is responsible for handling Git operations,
+ * particularly for fetching a repository by cloning it from a given URL.
+ * <p>
+ * This class currently supports cloning a repository using the
+ * {@link GitHandler}.
+ * </p>
+ */
 public class GitService {
 
     private static final GitHandler gitHandler = new GitHandler();

--- a/src/main/java/dd2480/group17/ciserver/service/GitService.java
+++ b/src/main/java/dd2480/group17/ciserver/service/GitService.java
@@ -6,7 +6,16 @@ public class GitService {
 
     private static final GitHandler gitHandler = new GitHandler();
 
-    // TODO call githubhandler to get the repository
+    /**
+     * Fetches the repository by cloning it from the specified URL, branch and
+     * target directory
+     * 
+     * @param repoUrl   the url of the repository
+     * @param branch    the branch to clone
+     * @param targetDir the directory where the repository should be cloned
+     * @return return true if the repository was successfully cloned, false
+     *         otherwise
+     */
     public boolean fetchRepository(String repoUrl, String branch, String targetDir) {
 
         boolean successful = gitHandler.cloneRepository(repoUrl, branch, targetDir);

--- a/src/main/java/dd2480/group17/ciserver/service/GitService.java
+++ b/src/main/java/dd2480/group17/ciserver/service/GitService.java
@@ -10,8 +10,7 @@ public class GitService {
     public boolean fetchRepository(String repoUrl, String branch, String targetDir) {
 
         boolean successful = gitHandler.cloneRepository(repoUrl, branch, targetDir);
-        // gitHandler.pullLatestChanges()
-        // gitHandler.checkoutCommit()
+
         return successful;
     }
 

--- a/src/main/java/dd2480/group17/ciserver/service/HistoryService.java
+++ b/src/main/java/dd2480/group17/ciserver/service/HistoryService.java
@@ -9,6 +9,15 @@ import dd2480.group17.ciserver.utils.LogParser;
 
 public class HistoryService {
 
+    /**
+     * Processes all log files within the specified directory path and returns a
+     * list of log entries
+     * 
+     * @param directoryPath the file system path to the directory containing log
+     *                      files
+     * @return a list of objects representing the parsed log entries,
+     *         return true empty list if no log files are found
+     */
     public static List<LogDTO> processAllLogsInDirectory(String directoryPath) {
         File dir = new File(directoryPath);
         File[] files = dir.listFiles((d, name) -> name.endsWith(".log"));

--- a/src/main/java/dd2480/group17/ciserver/service/HistoryService.java
+++ b/src/main/java/dd2480/group17/ciserver/service/HistoryService.java
@@ -7,6 +7,18 @@ import java.util.List;
 import dd2480.group17.ciserver.infrastructure.dto.LogDTO;
 import dd2480.group17.ciserver.utils.LogParser;
 
+/**
+ * The {@code HistoryService} class is responsible for processing log files
+ * located in a specified directory. It parses each log file into a
+ * {@link LogDTO}
+ * object, which encapsulates details about the log entry.
+ * <p>
+ * This service is particularly useful in a Continuous Integration (CI)
+ * environment
+ * where build logs are stored and need to be combined for reporting or
+ * debugging purposes.
+ * </p>
+ */
 public class HistoryService {
 
     /**

--- a/src/main/java/dd2480/group17/ciserver/service/TestService.java
+++ b/src/main/java/dd2480/group17/ciserver/service/TestService.java
@@ -4,22 +4,37 @@ import dd2480.group17.ciserver.infrastructure.MavenExecutor;
 import dd2480.group17.ciserver.infrastructure.dto.TestDTO;
 import dd2480.group17.ciserver.utils.Logger;
 
+/**
+ * The {@code TestService} class is responsible for executing the automated test
+ * suite
+ * for the project using Maven and logging the test results.
+ * <p>
+ * It leverages the {@link MavenExecutor} to run the tests and uses the
+ * {@link Logger}
+ * to record the output and any failed test details. This service plays a
+ * critical role in the
+ * Continuous Integration (CI) process by verifying that code changes meet the
+ * quality standards.
+ * </p>
+ */
 public class TestService {
 
     private static final MavenExecutor mavenExecutor = new MavenExecutor();
     private static final Logger logger = new Logger();
 
-    // TODO run tests
+    /**
+     * Execute the test suite for the project located at the specified repository
+     * path
+     * 
+     * @param repoPath the file system path to the repository containing the project
+     *                 to be tested
+     * @param commitId the commit hash that identifies the code state to be tested
+     * @return return true if all tests pass successfully, false if tests failed
+     */
+
     public boolean executeTests(String repoPath, String commitId) {
         TestDTO result = mavenExecutor.runTest(repoPath);
         logger.logTestEvent(commitId, result.getOutput(), result.getFailedTests());
         return result.isSuccess();
     }
-
-    // TODO get failed tests, (maybe we don't need this)
-    /*
-     * public List<String> getFailedTests(String repoPath) {
-     * 
-     * }
-     */
 }

--- a/src/main/java/dd2480/group17/ciserver/service/WebhookService.java
+++ b/src/main/java/dd2480/group17/ciserver/service/WebhookService.java
@@ -2,6 +2,18 @@ package dd2480.group17.ciserver.service;
 
 import dd2480.group17.ciserver.infrastructure.dto.WebhookDTO;
 
+/**
+ * The {@code WebhookService} class is responsible for processing incoming
+ * webhook events.
+ * <p>
+ * It is responsible for event handling to specific methods based on the event
+ * type.
+ * Currently, the class
+ * handles push events by cloning the repository, compiling the code, executing
+ * tests, and sending
+ * notifications based on the results via the NotificationService.
+ * </p>
+ */
 public class WebhookService {
 
     private static final GitService gitService = new GitService();
@@ -10,13 +22,39 @@ public class WebhookService {
     private static final NotificationService notificationService = new NotificationService();
     private static final HistoryService historyService = new HistoryService();
 
-    // TODO javadocs
+    /**
+     * Processes the incoming webhook event.
+     *
+     * @param webhookDTO the data transfer object containing the details of the
+     *                   webhook event
+     */
     public void processWebhookEvent(WebhookDTO webhookDTO) {
         // Error handling here or check if it is pushevent
         handlePushEvent(webhookDTO);
     }
 
-    // TODO get this work with other functions and javadocs
+    /**
+     * Handles push events triggered by the webhook.
+     * <p>
+     * This method performs the following steps:
+     * <ol>
+     * <li>Extracts the repository URL, branch, and commit hash from the webhook
+     * data.</li>
+     * <li>Constructs a build path using the commit hash.</li>
+     * <li>Attempts to clone the repository using {@link GitService}.</li>
+     * <li>If the clone is successful, compiles the code and executes tests via
+     * {@link CompileService} and {@link TestService}.</li>
+     * <li>Sends a success notification through {@link NotificationService} if both
+     * compilation
+     * and testing succeed; otherwise, sends a failure notification.</li>
+     * <li>If cloning fails or an exception occurs during processing, a failure
+     * notification is sent.</li>
+     * </ol>
+     * </p>
+     *
+     * @param webhookDTO the data transfer object containing the details of the push
+     *                   event
+     */
     private void handlePushEvent(WebhookDTO webhookDTO) {
         String repoUrl = webhookDTO.repository().htmlUrl();
         String branch = webhookDTO.branch();


### PR DESCRIPTION
I added Javadoc for all functions and classes for files under "service" folder.

But, I have not removed comments that are commented out by other member because I don't know if I should or not.

　　　　　↓

Under WebhookService.java

    // Notify failure to clone repository
    // notificationService.notifyFailure("Failed to clone repository.");

Other than that, everything is okay!!